### PR TITLE
docs: add macOS build instructions and reorganize platform setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,11 @@ Feel free to join our [Discord server](https://discord.gg/8PET8w8PU8) if you hav
 All platforms require:
 - A legally obtained ROM of *Rhythm Tengoku* **(Rev 0)** (CRC32: `349D7025`)
 - Git
+- Python 3
 
-### Windows
+### Platform setup
+
+#### Windows
 
 Use the [Linux instructions](#linux) via Windows Subsystem for Linux (WSL). Debian or Ubuntu distributions are recommended.
 
@@ -43,37 +46,70 @@ To set up WSL:
 wsl --install
 ```
 
-Then follow the Linux build instructions below.
+Then use the Linux setup below, followed by the build instructions.
 
-### Linux
-
-#### Dependencies
+#### Linux
 
 Install the required packages (Ubuntu/Debian):
 ```bash
 sudo apt update
-sudo apt install build-essential binutils-arm-none-eabi git libpng-dev ffmpeg
+sudo apt install build-essential binutils-arm-none-eabi git libpng-dev ffmpeg python3
 ```
 
-#### Install devkitPro
-
+Install devkitPro:
 ```bash
-# Download and install devkitPro pacman (using my mirror for now)
-wget https://www.shaffy.fr/install-devkitpro-pacman
+wget https://apt.devkitpro.org/install-devkitpro-pacman
 chmod +x ./install-devkitpro-pacman
 sudo ./install-devkitpro-pacman
+```
 
-# Set environment variables
+#### macOS
+
+Install [Homebrew](https://brew.sh/) if you haven't already, then install the required packages:
+```bash
+xcode-select --install
+brew install libpng ffmpeg python
+```
+
+Download `devkitpro-pacman-installer.pkg` from the [devkitPro/pacman releases](https://github.com/devkitPro/pacman/releases), then install it:
+```bash
+sudo installer -pkg /path/to/devkitpro-pacman-installer.pkg -target /
+```
+
+Open a new terminal after installing devkitPro pacman, or add it to your current shell:
+```bash
+export PATH=/opt/devkitpro/pacman/bin:$PATH
+```
+
+### Build instructions
+
+#### Set environment variables
+
+Set the devkitPro environment variables:
+```bash
 export DEVKITPRO=/opt/devkitpro
 export DEVKITARM=/opt/devkitpro/devkitARM
 export DEVKITPPC=/opt/devkitpro/devkitPPC
+```
 
-# Install GBA development tools
+To keep these settings for future terminals, add them to your shell profile. For the default macOS shell:
+```bash
+echo 'export DEVKITPRO=/opt/devkitpro' >> ~/.zshrc
+echo 'export DEVKITARM=/opt/devkitpro/devkitARM' >> ~/.zshrc
+echo 'export DEVKITPPC=/opt/devkitpro/devkitPPC' >> ~/.zshrc
+echo 'export PATH=/opt/devkitpro/pacman/bin:$PATH' >> ~/.zshrc
+```
+
+If your shell is bash, use `~/.bashrc` instead of `~/.zshrc`.
+
+#### Install GBA development tools
+
+```bash
 sudo dkp-pacman -Sy
 sudo dkp-pacman -S gba-dev
 ```
 
-#### Clone and Build
+#### Clone and build
 
 1. **Clone this repository:**
    ```bash
@@ -94,15 +130,24 @@ sudo dkp-pacman -S gba-dev
    - Rename it to `baserom.gba` (or as specified in the Makefile)
 
 4. **Build the project:**
+   On Linux:
    ```bash
    make -j$(nproc)
    ```
 
-The patched ROM will be generated in the `build/` directory.
+   On macOS:
+   ```bash
+   make -j$(sysctl -n hw.logicalcpu)
+   ```
 
-### macOS
+The built ROM will be generated at `build/rhythmheavenadvance.gba`.
 
-macOS build instructions are coming soon! (Pull request appreciated...)
+To create a BPS patch instead, install [Floating IPS](https://github.com/Alcaro/Flips), make sure `flips` is in your `PATH`, then run:
+```bash
+make patch
+```
+
+The patch will be generated at `build/rhythmheavenadvance.bps`.
 
 ## Credits
 Check out the full credits [here](CREDITS.md)!


### PR DESCRIPTION
Adds macOS build instructions (Homebrew, xcode-select, devkitPro pkg installer, platform-specific make command) and reorganizes the build section into a cleaner hierarchy: platform-specific setup (Windows/Linux/macOS) followed by shared build steps (env vars, gba-dev, clone/build).

Also adds:
- Python 3 as a prerequisite (needed for sample_parser.py and compression.py)
- Explicit output filename and  target documentation
- Shell profile persistence instructions for env vars